### PR TITLE
create function for predict height of header.

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -1,16 +1,23 @@
 <script setup>
-defineProps({
+const props = defineProps({
   height: {
     type: Number,
     default: 300,
   },
+});
+
+// predict height with animated background loaded
+const headerHeight = computed(() => {
+  // total row icons
+  const total = Math.round(props.height / 60);
+  // 110px is real size for row
+  return `${total * 110}px`;
 });
 </script>
 
 <template>
   <header
     class="relative grid col-span-1 overflow-hidden bg-darkPurple place-items-center"
-    :class="`h-[${height}px]`"
   >
     <Navbar />
     <div class="z-10 col-start-1 row-start-1">
@@ -30,5 +37,6 @@ defineProps({
 <style scoped>
 header {
   clip-path: polygon(0 0, 100% 0, 100% 90%, 0 100%);
+  height: v-bind('headerHeight');
 }
 </style>


### PR DESCRIPTION
:class="`h-[${height}px]`" don't work because Tailwind can't know the value of height. The classe isn't created by tailwind.